### PR TITLE
Don't compress.  Reduce!

### DIFF
--- a/app/components/MonitorPanel.jsx
+++ b/app/components/MonitorPanel.jsx
@@ -3,17 +3,17 @@ var RequestGraph = require('./RequestGraph.jsx')
 
 var MonitorPanel = React.createClass({
     getCircuitStatus: function() {
-        if(this.props.data.propertyValue_circuitBreakerForceOpen) {
+        if(this.props.data.circuitBreaker_forcedOpen) {
             return <span className="status-value status-forced-open">Forced Open</span>
         }
 
-        if(this.props.data.propertyValue_circuitBreakerForceClosed) {
+        if(this.props.data.circuitBreaker_forcedClosed) {
             return <span className="status-value status-forced-closed">Forced Closed</span>
         }
 
         // This value defaults to a boolean but then gets set as an object in clustered mode
         // if some hosts are open.  This is stupid, but whatever.
-        var circuitStatus = this.props.data.isCircuitBreakerOpen
+        var circuitStatus = this.props.data.circuitBreaker_open
         if(circuitStatus === false) {
             return <span className="status-value status-closed">Closed</span>
         }
@@ -22,13 +22,13 @@ var MonitorPanel = React.createClass({
             return <span className="status-value status-open">Open</span>
         }
 
-        var openPercentage = (this.props.data.isCircuitBreakerOpen["true"] / this.props.data.reportingHosts) * 100
+        var openPercentage = (this.props.data.circuitBreaker_open["true"] / this.props.data.reportingHosts) * 100
 
         return <span className="status-value status-partial-open">Open ({openPercentage}%)</span>
     },
     getCircuitBreaker: function() {
         var rejectedCount = this.props.data.rollingCountThreadPoolRejected
-        if(this.props.data.propertyValue_executionIsolationStrategy == 'SEMAPHORE') {
+        if(this.props.data.execution_isolationStrategy == 'SEMAPHORE') {
             rejectedCount = this.props.data.rollingCountSemaphoreRejected
         }
 
@@ -95,7 +95,7 @@ var MonitorPanel = React.createClass({
     },
     getThreadPool: function() {
         var rejectedCount = this.props.data.rollingCountThreadPoolRejected
-        if(this.props.data.propertyValue_executionIsolationStrategy == 'SEMAPHORE') {
+        if(this.props.data.execution_isolationStrategy == 'SEMAPHORE') {
             rejectedCount = this.props.data.rollingCountSemaphoreRejected
         }
 

--- a/src/main/java/com/nuclearfurnace/oscilloscope/resources/ClusterResource.java
+++ b/src/main/java/com/nuclearfurnace/oscilloscope/resources/ClusterResource.java
@@ -17,7 +17,6 @@ public class ClusterResource
     private final DiscoveryManager discoveryManager;
 
     public ClusterResource(DiscoveryManager discoveryManager) {
-
         this.discoveryManager = discoveryManager;
     }
 

--- a/src/main/java/com/nuclearfurnace/oscilloscope/resources/StreamResource.java
+++ b/src/main/java/com/nuclearfurnace/oscilloscope/resources/StreamResource.java
@@ -7,6 +7,7 @@ import com.netflix.turbine.aggregator.StreamAggregator;
 import com.netflix.turbine.aggregator.TypeAndNameKey;
 import com.netflix.turbine.discovery.StreamAction;
 import com.netflix.turbine.internal.JsonUtility;
+import com.nuclearfurnace.oscilloscope.utility.HystrixMetricsTransformer;
 import io.netty.buffer.ByteBuf;
 import io.reactivex.netty.RxNetty;
 import io.reactivex.netty.pipeline.PipelineConfigurators;
@@ -130,8 +131,7 @@ public class StreamResource
                 @Override
                 public void onNext(Map<String, Object> event) {
                     try {
-                        String eventAsJson = JsonUtility.mapToJson(event);
-                        logger.debug("Writing event to stream; event: {} bytes", eventAsJson.length());
+                        String eventAsJson = HystrixMetricsTransformer.toPrunedJson(event);
 
                         outputStream.write("data: ".getBytes());
                         outputStream.write(eventAsJson.getBytes());
@@ -160,7 +160,9 @@ public class StreamResource
             }
         };
 
-        return Response.ok(streamingOutput).header("Access-Control-Allow-Origin", "*").build();
+        return Response.ok(streamingOutput)
+                .header("Access-Control-Allow-Origin", "*")
+                .build();
     }
 
     /**

--- a/src/main/java/com/nuclearfurnace/oscilloscope/utility/HystrixMetricsTransformer.java
+++ b/src/main/java/com/nuclearfurnace/oscilloscope/utility/HystrixMetricsTransformer.java
@@ -1,0 +1,54 @@
+package com.nuclearfurnace.oscilloscope.utility;
+
+import com.netflix.turbine.internal.JsonUtility;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class HystrixMetricsTransformer {
+    private static final ArrayList<String> keysToRemove;
+    private static final HashMap<String, String> keysToReplace;
+
+    static {
+        keysToRemove = new ArrayList<>();
+        keysToRemove.add("propertyValue_metricsRollingStatisticalWindowInMilliseconds");
+        keysToRemove.add("propertyValue_circuitBreakerRequestVolumeThreshold");
+        keysToRemove.add("propertyValue_circuitBreakerSleepWindowInMilliseconds");
+        keysToRemove.add("propertyValue_circuitBreakerErrorThresholdPercentage");
+        keysToRemove.add("propertyValue_executionIsolationSemaphoreMaxConcurrentRequests");
+        keysToRemove.add("propertyValue_executionIsolationThreadInterruptOnTimeout");
+        keysToRemove.add("propertyValue_executionIsolationThreadPoolKeyOverride");
+        keysToRemove.add("propertyValue_executionIsolationThreadTimeoutInMilliseconds");
+        keysToRemove.add("propertyValue_executionTimeoutInMilliseconds");
+        keysToRemove.add("propertyValue_requestCacheEnabled");
+        keysToRemove.add("propertyValue_requestLogEnabled");
+        keysToRemove.add("propertyValue_fallbackIsolationSemaphoreMaxConcurrentRequests");
+        keysToRemove.add("TypeAndName");
+        keysToRemove.add("InstanceKey");
+
+        keysToReplace = new HashMap<>();
+        keysToReplace.put("propertyValue_circuitBreakerForceOpen", "circuitBreaker_forcedOpen");
+        keysToReplace.put("propertyValue_circuitBreakerForceClosed", "circuitBreaker_forcedClosed");
+        keysToReplace.put("propertyValue_circuitBreakerEnabled", "circuitBreaker_enabled");
+        keysToReplace.put("isCircuitBreakerOpen", "circuitBreaker_open");
+        keysToReplace.put("propertyValue_executionIsolationStrategy", "execution_isolationStrategy");
+    }
+
+    public static String toPrunedJson(Map<String, Object> event) {
+        Map<String, Object> newEvent = new HashMap<>(event);
+
+        for(String keyToRemove : keysToRemove) {
+            newEvent.remove(keyToRemove);
+        }
+
+        for(Map.Entry<String, String> keyToReplace : keysToReplace.entrySet()) {
+            Object val = newEvent.remove(keyToReplace.getKey());
+            if(val != null) {
+                newEvent.put(keyToReplace.getValue(), val);
+            }
+        }
+
+        return JsonUtility.mapToJson(newEvent);
+    }
+}


### PR DESCRIPTION
Rather than trying to do compression for streaming data -- which seems to be nigh impossible with the built-in Java stuff -- we can get a lot of bang for our buck by reducing the number of property values we send to the browser.  A lot of them don't show up at all in the UI, and are purely informational and otherwise duplicate information you could get by simply looking at the configuration you have for the commands/thread pools themselves.

In the future, we could potentially use something like Protocol Buffers/Thrift which have a rigid schema and don't require key name, letting us get down to literally just the data being expressed.  I don't think we'll get much better than that, including with compression, if we want to stream real-time.
